### PR TITLE
Changed error verb usage

### DIFF
--- a/stimpl/expression.py
+++ b/stimpl/expression.py
@@ -166,7 +166,7 @@ class Gt(BinaryOperator):
         super().__init__(left, right)
 
     def __repr__(self):
-        return f"{self.left} < {self.right}"
+        return f"{self.left} > {self.right}"
 
 
 class Gte(BinaryOperator):
@@ -174,7 +174,7 @@ class Gte(BinaryOperator):
         super().__init__(left, right)
 
     def __repr__(self):
-        return f"{self.left} <= {self.right}"
+        return f"{self.left} >= {self.right}"
 
 
 class Eq(BinaryOperator):

--- a/stimpl/runtime.py
+++ b/stimpl/runtime.py
@@ -141,7 +141,7 @@ def evaluate(expression: Expr, state: State) -> Tuple[Optional[Any], Type, State
 
             if left_type != right_type:
                 raise InterpTypeError(f"""Mismatched types for And:
-            Cannot add {left_type} to {right_type}""")
+            Cannot evaluate {left_type} and {right_type}""")
             match left_type:
                 case Boolean():
                     result = left_value and right_value
@@ -171,7 +171,7 @@ def evaluate(expression: Expr, state: State) -> Tuple[Optional[Any], Type, State
 
             if left_type != right_type:
                 raise InterpTypeError(f"""Mismatched types for Lt:
-            Cannot compare {left_type} to {right_type}""")
+            Cannot compare {left_type} and {right_type}""")
 
             match left_type:
                 case Integer() | Boolean() | String() | FloatingPoint():


### PR DESCRIPTION
Hello 😄 

I made some minor changes to the error messages in the `And` and `Lt` functions.
- For `And`, "Cannot add {left_type} to {right_type}" is changed to "Cannot *evaluate* {left_type} *and* {right_type}" (*and* here is intended to be the logical operator name)
- For `Lt`, "Cannot compare {left_type} to {right_type}" is changed to "Cannot compare {left_type} *and* {right_type}"
- I also made some more small changes in the expressions folder, specifically the debug `__repr__` function in `Gt` and `Gte`, changing `<` and `<=` to `>` and `>=` respectively.

I hope these changes align with your intention.