### PR TITLE
Rework to avoid auto passing of test

### DIFF
--- a/stimpl/runtime.py
+++ b/stimpl/runtime.py
@@ -115,8 +115,9 @@ def evaluate(expression: Expr, state: State) -> Tuple[Optional[Any], Type, State
                 raise InterpTypeError(f"""Mismatched types for Add:
             Cannot add {left_type} to {right_type}""")
 
+            """ TODO: Implement. """
             match left_type:
-                case Integer() | String() | FloatingPoint():
+                case Integer() | FloatingPoint():
                     result = left_result + right_result
                 case _:
                     raise InterpTypeError(f"""Cannot add {left_type}s""")


### PR DESCRIPTION
Currently, the student receives an automatic 5 points simply for submitting, as one of the tests is already implemented. 


If the student is following the sections labeled `""" TODO: Implement. """`, there is nigh nothing the user can do to fail this test. I'm not certain this is intended, and it feels wrong to me. I removed the string concatenation from `Add()`, in [runtime.py](https://github.com/SamuelWeese/stimpl/blob/f57f097f6f120f3f1f6a103703b8336bd638cc68/stimpl/runtime.py#L118) to allow the student to have an opportunity to implement correct code. 


I'm happy to rework this to have other solutions, including larger string support, removal/rework of the current testing method, or anything else you might suggest Dr. Hawkins!