### PR TITLE
Change return value for Ren() case to None

### DIFF
--- a/stimpl/runtime.py
+++ b/stimpl/runtime.py
@@ -50,7 +50,7 @@ Main evaluation logic!
 def evaluate(expression: Expr, state: State) -> Tuple[Optional[Any], Type, State]:
     match expression:
         case Ren():
-            return ((), Unit(), state)
+            return (None, Unit(), state)
 
         case IntLiteral(literal=l):
             return (l, Integer(), state)


### PR DESCRIPTION
Error on line 269 of test.py expects None for a Ren(), but Ren() case in runtime.py is returning an empty tuple '()'.
Test case Expecting: ( None, Unit )
Original Ren() return: ( (), Unit )